### PR TITLE
Fix no start/end time calculated

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Restart Home-Assistant and add the integration.
 
 ## Setup
 
-Adaptive Cover supports (for now) two types of covers/blinds; Vertical and Horizontal.
+Adaptive Cover supports (for now) three types of covers/blinds; Vertical and Horizontal and Venetian (Tilted) blinds.
 Each type has its own specific parameters to setup a sensor. To setup the sensor you first need to find out the azimuth of the window(s). This can be done by finding your location on [Open Street Map Compass](https://osmcompass.com/).
 
 ### Simulation

--- a/custom_components/adaptive_cover/calculation.py
+++ b/custom_components/adaptive_cover/calculation.py
@@ -61,8 +61,14 @@ class AdaptiveCoverCalculator(
         """Determine start/end times"""
         df_today = pd.DataFrame({"azimuth":self.sun_data.solar_azimuth, "elevation":self.sun_data.solar_elevation})
         solpos = df_today.set_index(self.sun_data.times)
-        frame = (solpos["azimuth"] > self.azi_min_abs) & (solpos["azimuth"] < self.azi_max_abs) & (solpos["elevation"] > 0)
-        return solpos[frame].index[0].to_pydatetime(), solpos[frame].index[-1].to_pydatetime()
+
+        alpha = solpos["azimuth"]
+        frame = ((alpha - self.azi_min_abs) % 360 <= (self.azi_max_abs - self.azi_min_abs) % 360) & (solpos["elevation"] > 0)
+
+        if solpos[frame].empty:
+            return None, None
+        else:
+            return solpos[frame].index[0].to_pydatetime(), solpos[frame].index[-1].to_pydatetime()
 
     def value(self, value: any):
         """Return input value"""


### PR DESCRIPTION
resolves #8 

Return `null` for both times if the sun does not appear above the horizon within the field of view of the window.
And adjust the conditions for the timeframe to work correctly if field of view crosses azimuth 360/0.