### PR TITLE
Improve logging by adding configuration name and increasing log points

### DIFF
--- a/custom_components/adaptive_cover/__init__.py
+++ b/custom_components/adaptive_cover/__init__.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_TEMP_ENTITY,
     CONF_WEATHER_ENTITY,
     DOMAIN,
+    _LOGGER,
 )
 from .coordinator import AdaptiveDataUpdateCoordinator
 
@@ -47,6 +48,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     for entity in [_temp_entity, _presence_entity, _weather_entity, _end_time_entity]:
         if entity is not None:
             _entities.append(entity)
+
+    _LOGGER.debug("Setting up entry %s", entry.data.get("name"))
 
     entry.async_on_unload(
         async_track_state_change_event(

--- a/custom_components/adaptive_cover/calculation.py
+++ b/custom_components/adaptive_cover/calculation.py
@@ -90,6 +90,7 @@ class AdaptiveGeneralCover(ABC):
             blindspot = (self.gamma <= left_edge) & (self.gamma >= right_edge)
             if self.blind_spot_elevation is not None:
                 blindspot = blindspot & (self.sol_elev <= self.blind_spot_elevation)
+            self.logger.debug("Is sun in blind spot? %s", blindspot)
             return blindspot
         return False
 
@@ -121,7 +122,9 @@ class AdaptiveGeneralCover(ABC):
             return self.sol_elev <= self.max_elevation
         if self.max_elevation is None:
             return self.sol_elev >= self.min_elevation
-        return self.min_elevation <= self.sol_elev <= self.max_elevation
+        within_range = self.min_elevation <= self.sol_elev <= self.max_elevation
+        self.logger.debug("elevation within range? %s", within_range)
+        return within_range
 
     @property
     def valid(self) -> bool:
@@ -134,6 +137,7 @@ class AdaptiveGeneralCover(ABC):
         valid = (
             (self.gamma < azi_min) & (self.gamma > -azi_max) & (self.valid_elevation)
         )
+        self.logger.debug("sun in front of window? %s", valid)
         return valid
 
     @property
@@ -144,6 +148,9 @@ class AdaptiveGeneralCover(ABC):
         after_sunset = datetime.utcnow() > (sunset + timedelta(minutes=self.sunset_off))
         before_sunrise = datetime.utcnow() < (
             sunrise + timedelta(minutes=self.sunrise_off)
+        )
+        self.logger.debug(
+            "after sunset plus offset? %s", (after_sunset or before_sunrise)
         )
         return after_sunset or before_sunrise
 
@@ -199,11 +206,18 @@ class NormalCoverState:
 
     def get_state(self) -> int:
         """Return state."""
-        state = np.where(
-            self.cover.direct_sun_valid,
-            self.cover.calculate_percentage(),
-            self.cover.default,
-        )
+        self.cover.logger.debug("Calculating state")
+        dsv = self.cover.direct_sun_valid
+        self.cover.logger.debug("Direct sun valid: %s", dsv)
+        if dsv:
+            state = self.cover.calculate_percentage()
+        else:
+            state = self.cover.default
+        if dsv:
+            self.cover.logger.debug("Calculated the percentage")
+        else:
+            self.cover.logger.debug("Using default value")
+
         result = np.clip(state, 0, 100)
         if self.cover.apply_max_position and result > self.cover.max_pos:
             return self.cover.max_pos
@@ -308,6 +322,12 @@ class ClimateCoverData:
     @property
     def is_summer(self) -> bool:
         """Check if temperature is over threshold."""
+        self.logger.debug(
+            "is summer calc? temp_high, current_temp, outside_high: %s, %s, %s",
+            self.temp_high,
+            self.get_current_temperature,
+            self.outside_high,
+        )
         if self.temp_high is not None and self.get_current_temperature is not None:
             return self.get_current_temperature > self.temp_high and self.outside_high
         return False
@@ -360,6 +380,13 @@ class ClimateCoverState(NormalCoverState):
     def normal_with_presence(self) -> int:
         """Determine state for horizontal and vertical covers with occupants."""
 
+        self.cover.logger.debug(
+            "is summer? %s; is winter? %s; is_sunny? %s",
+            self.climate_data.is_summer,
+            self.climate_data.is_winter,
+            self.climate_data.is_sunny,
+        )
+
         # Check if it's not summer and either lux, irradiance or sunny weather is present
         if not self.climate_data.is_summer and (
             self.climate_data.lux
@@ -368,8 +395,10 @@ class ClimateCoverState(NormalCoverState):
         ):
             # If it's winter and the cover is valid, return 100
             if self.climate_data.is_winter and self.cover.valid:
+                self.cover.logger.debug("Winter and sun is in front of window")
                 return 100
             # Otherwise, return the default cover state
+            self.cover.logger.debug("it's not summer and sunny weather is not present")
             return self.cover.default
 
         # If it's summer and there's a transparent blind, return 0
@@ -377,6 +406,7 @@ class ClimateCoverState(NormalCoverState):
             return 0
 
         # If none of the above conditions are met, get the state from the parent class
+        self.cover.logger.debug("None of the climate conditions are met")
         return super().get_state()
 
     def normal_without_presence(self) -> int:
@@ -454,7 +484,11 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
 
     def calculate_percentage(self) -> float:
         """Convert blind height to percentage or default value."""
-        result = self.calculate_position() / self.h_win * 100
+        position = self.calculate_position()
+        self.logger.debug(
+            "Converting height to percentage: %s / %s * 100", position, self.h_win
+        )
+        result = position / self.h_win * 100
         return round(result)
 
 

--- a/custom_components/adaptive_cover/calculation.py
+++ b/custom_components/adaptive_cover/calculation.py
@@ -13,6 +13,7 @@ from numpy import radians as rad
 
 from .helpers import get_domain, get_safe_state
 from .sun import SunData
+from .config_context_adapter import ConfigContextAdapter
 
 
 @dataclass
@@ -20,6 +21,7 @@ class AdaptiveGeneralCover(ABC):
     """Collect common data."""
 
     hass: HomeAssistant
+    logger: ConfigContextAdapter
     sol_azi: float
     sol_elev: float
     sunset_pos: int
@@ -215,6 +217,7 @@ class ClimateCoverData:
     """Fetch additional data."""
 
     hass: HomeAssistant
+    logger: ConfigContextAdapter
     temp_entity: str
     temp_low: float
     temp_high: float

--- a/custom_components/adaptive_cover/config_context_adapter.py
+++ b/custom_components/adaptive_cover/config_context_adapter.py
@@ -1,0 +1,43 @@
+"""This module provides a logging adapter that adds a configuration name to log messages."""
+
+import logging
+
+
+class ConfigContextAdapter(logging.LoggerAdapter):
+    """A logging adapter that adds a configuration name to log messages."""
+
+    def __init__(self, logger, extra=None):
+        """Initialize the ConfigContextAdapter.
+
+        Args:
+            logger (logging.Logger): The logger instance to which this adapter is attached.
+            extra (dict, optional): Additional context information. Defaults to None.
+
+        """
+        super().__init__(logger, extra or {})
+        self.config_name = None
+
+    def set_config_name(self, config_name):
+        """Set the configuration name.
+
+        Args:
+            config_name (str): The name of the configuration to set.
+
+        """
+        self.config_name = config_name
+
+    def process(self, msg, kwargs):
+        """Process the log message and add the configuration name if set.
+
+        Args:
+            msg (str): The log message.
+            kwargs (dict): Additional keyword arguments.
+
+        Returns:
+            tuple: The processed log message and keyword arguments.
+
+        """
+        if self.config_name:
+            return f"[{self.config_name}] {msg}", kwargs
+        else:
+            return f"[Unknown] {msg}", kwargs

--- a/custom_components/adaptive_cover/coordinator.py
+++ b/custom_components/adaptive_cover/coordinator.py
@@ -285,8 +285,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Access climate data if climate mode is enabled
         if self._climate_mode:
             self.climate_mode_data(options, cover_data)
-
-        self.logger.debug("Control method is %s", self.control_method)
+        else:
+            self.logger.debug("Control method is %s", self.control_method)
 
         # calculate the state of the cover
         self.normal_cover_state = NormalCoverState(cover_data)
@@ -397,6 +397,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
     async def async_handle_timed_refresh(self, options):
         """Handle timed refresh."""
+        self.logger.debug(
+            "This is a timed refresh, using sunset position: %s",
+            options.get(CONF_SUNSET_POS),
+        )
         if self.control_toggle:
             for cover in self.entities:
                 await self.async_set_manual_position(
@@ -679,7 +683,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self.control_method = "summer"
         if climate_data.is_winter and self.switch_mode:
             self.control_method = "winter"
-        self.logger.debug("Climate mode control method is %s", self.control_method)
+        self.logger.debug(
+            "Climate mode control method was set to %s", self.control_method
+        )
 
     def vertical_data(self, options):
         """Update data for vertical blinds."""
@@ -706,12 +712,16 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     @property
     def state(self) -> int:
         """Handle the output of the state based on mode."""
-        state = self.default_state
-        self.logger.debug("Starting with default mode position: %s", state)
-
+        self.logger.debug(
+            "Basic position: %s; Climate position: %s; Using climate position? %s",
+            self.default_state,
+            self.climate_state,
+            self._switch_mode,
+        )
         if self._switch_mode:
             state = self.climate_state
-            self.logger.debug("Using climate mode position: %s", state)
+        else:
+            state = self.default_state
 
         if self._use_interpolation:
             self.logger.debug("Interpolating position: %s", state)

--- a/custom_components/adaptive_cover/coordinator.py
+++ b/custom_components/adaptive_cover/coordinator.py
@@ -865,6 +865,12 @@ class AdaptiveCoverManager:
                 )
                 return
             self.logger.debug(
+                "Manual change detected for %s. Our state: %s, new state: %s",
+                entity_id,
+                our_state,
+                new_position,
+            )
+            self.logger.debug(
                 "Set manual control for %s, for at least %s seconds, reset_allowed: %s",
                 entity_id,
                 self.reset_duration.total_seconds(),

--- a/custom_components/adaptive_cover/switch.py
+++ b/custom_components/adaptive_cover/switch.py
@@ -14,7 +14,6 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
-    _LOGGER,
     CONF_CLIMATE_MODE,
     CONF_ENTITIES,
     CONF_IRRADIANCE_ENTITY,
@@ -148,6 +147,8 @@ class AdaptiveCoverSwitch(
             name=self._device_name,
         )
 
+        self.coordinator.logger.debug("Setup switch")
+
     @property
     def name(self):
         """Name of the entity."""
@@ -155,6 +156,7 @@ class AdaptiveCoverSwitch(
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
+        self.coordinator.logger.debug("Turning on")
         self._attr_is_on = True
         setattr(self.coordinator, self._key, True)
         if self._key == "control_toggle" and kwargs.get("added") is not True:
@@ -171,6 +173,7 @@ class AdaptiveCoverSwitch(
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
+        self.coordinator.logger.debug("Turning off")
         self._attr_is_on = False
         setattr(self.coordinator, self._key, False)
         if self._key == "control_toggle" and kwargs.get("added") is not True:
@@ -182,7 +185,7 @@ class AdaptiveCoverSwitch(
     async def async_added_to_hass(self) -> None:
         """Call when entity about to be added to hass."""
         last_state = await self.async_get_last_state()
-        _LOGGER.debug("%s: last state is %s", self._name, last_state)
+        self.coordinator.logger.debug("%s: last state is %s", self._name, last_state)
         if (last_state is None and self._initial_state) or (
             last_state is not None and last_state.state == STATE_ON
         ):


### PR DESCRIPTION
Does two things:

1) Creates a special context logger that provides the context of the adaptive cover entity that is running. I have over a dozen adaptive cover configurations so it's important when I'm trying to understand what is happening for the logs to distinguish between them.

Example output:
```
2025-04-28 16:24:44.990 DEBUG (MainThread) [custom_components.adaptive_cover.const] [TV] Final position to use: 5
```

2) Adds logging to more locations

## Motivation and Context

I have many different configurations and also some of them are complicated (e.g. trying to set up blind spots, climate configuration), and I sometimes can't tell why the shade is not doing what I expect.

This solves two issues (I'm open to splitting them if one is desired on its own)

1) inability to distinguish adaptive cover configurations in the logs
2) insufficient information to diagnose problems

## How has this been tested?

It has been run locally for a period of time.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking which updates existing code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Other comments

This does add a fair bit of extra log spam. If it's too much, but the addition of context to the log would be welcome, I am happy to separate out that section of the PR
