### PR TITLE
Fix config flow for HomeAssistant 2025.12

### DIFF
--- a/custom_components/adaptive_cover/config_flow.py
+++ b/custom_components/adaptive_cover/config_flow.py
@@ -637,7 +637,6 @@ class OptionsFlowHandler(OptionsFlow):
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize options flow."""
         # super().__init__(config_entry)
-        self.config_entry = config_entry
         self.current_config: dict = dict(config_entry.data)
         self.options = dict(config_entry.options)
         self.sensor_type: SensorType = (

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "Adaptive Cover",
   "filename": "adaptive_cover.zip",
-  "homeassistant": "2024.5.0b1",
+  "homeassistant": "2024.12.0",
   "render_readme": true,
   "zip_release": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-homeassistant~=2024.5
+homeassistant>=2024.12.0
 pip>=24.1.1,<24.3
 pandas~=2.2


### PR DESCRIPTION

## Description

https://github.com/home-assistant/core/pull/129562 (2024.12) deprecated assigning `self.config_entry` in an `OptionsFlow`; this was removed in 2025.12 with https://github.com/home-assistant/core/pull/155958. Remove the assignment.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- fixes: #437, #438.

## How has this been tested?

Edited configuration in HomeAssistant 2025.12

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking which updates existing code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
