### PR TITLE
Fix OptionsFlow deprecation for HA 2025.12

### DIFF
--- a/custom_components/adaptive_cover/config_flow.py
+++ b/custom_components/adaptive_cover/config_flow.py
@@ -636,8 +636,9 @@ class OptionsFlowHandler(OptionsFlow):
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize options flow."""
-        # super().__init__(config_entry)
-        self.config_entry = config_entry
+        # HA 2025.12+ exposes ``config_entry`` as a read-only property on
+        # ``OptionsFlow`` and injects it automatically, so we must not
+        # assign it here anymore (was deprecated since HA 2024.12).
         self.current_config: dict = dict(config_entry.data)
         self.options = dict(config_entry.options)
         self.sensor_type: SensorType = (


### PR DESCRIPTION
## Description

Since HA 2025.12, assigning ``self.config_entry`` inside an ``OptionsFlow.__init__`` raises:

```
AttributeError: property 'config_entry' of 'OptionsFlowHandler' object has no setter
```

Background:
- HA 2024.12 deprecated the assignment (home-assistant/core#129562)
- HA 2025.12 turned ``config_entry`` into a read-only property and removed the setter (home-assistant/core#155958)

The framework injects ``config_entry`` automatically, so the line in ``OptionsFlowHandler.__init__`` can just be removed. Every other use of ``self.config_entry`` in the class keeps working through the property.

Without this, every HA 2025.12+ user is locked out of editing their Adaptive Cover configuration.

## Motivation and Context

- Fixes #437
- Fixes #438
- Addresses long-standing deprecation warnings #364 and #348

## How has this been tested?

- Reconfigured an existing Adaptive Cover entry on HA 2026.4 (same code path as 2025.12+), Options dialog opens and saves cleanly
- Re-opened Options after save, values persist
- Fresh config flow still works

## Notes

References the closed PR #439 which proposed the same one-line fix but was never merged. This PR keeps the change minimal (single file, no unrelated version bumps) to make review trivial.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.