### PR TITLE
fix: replace template state_attr with native state API

### DIFF
--- a/custom_components/adaptive_cover/calculation.py
+++ b/custom_components/adaptive_cover/calculation.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 import numpy as np
 import pandas as pd
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.template import state_attr
 from numpy import cos, sin, tan
 from numpy import radians as rad
 
@@ -262,7 +261,8 @@ class ClimateCoverData:
                 self.outside_entity,
             )
         elif self.weather_entity:
-            temp = state_attr(self.hass, self.weather_entity, "temperature")
+            state = self.hass.states.get(self.weather_entity)
+            temp = state.attributes.get("temperature") if state else None
         return temp
 
     @property
@@ -275,7 +275,8 @@ class ClimateCoverData:
                     self.temp_entity,
                 )
             else:
-                temp = state_attr(self.hass, self.temp_entity, "current_temperature")
+                state = self.hass.states.get(self.temp_entity)
+                temp = state.attributes.get("current_temperature") if state else None
             return temp
 
     @property

--- a/custom_components/adaptive_cover/coordinator.py
+++ b/custom_components/adaptive_cover/coordinator.py
@@ -23,7 +23,6 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.helpers.event import async_track_point_in_time
-from homeassistant.helpers.template import state_attr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .config_context_adapter import ConfigContextAdapter
@@ -567,9 +566,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
     def _get_current_position(self, entity) -> int | None:
         """Get current position of cover."""
+        state = self.hass.states.get(entity)
         if self._cover_type == "cover_tilt":
-            return state_attr(self.hass, entity, "current_tilt_position")
-        return state_attr(self.hass, entity, "current_position")
+            return state.attributes.get("current_tilt_position") if state else None
+        return state.attributes.get("current_position") if state else None
 
     def check_position(self, entity, state):
         """Check if position is different as state."""
@@ -622,9 +622,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     @property
     def pos_sun(self):
         """Fetch information for sun position."""
+        state = self.hass.states.get("sun.sun")
         return [
-            state_attr(self.hass, "sun.sun", "azimuth"),
-            state_attr(self.hass, "sun.sun", "elevation"),
+            state.attributes.get("azimuth") if state else None,
+            state.attributes.get("elevation") if state else None,
         ]
 
     def common_data(self, options):


### PR DESCRIPTION
## Description

Replace all usages of `state_attr()` from `homeassistant.helpers.template` with direct calls to the HA state API in `coordinator.py` and `calculation.py`.

The affected call sites are:
- `coordinator.py` — `_get_current_position` (cover position/tilt attributes) and `pos_sun` (sun azimuth/elevation)
- `calculation.py` — `ClimateCoverData.outside_temperature` (weather entity temperature) and `ClimateCoverData.inside_temperature` (climate entity current temperature)

Each call is replaced with the equivalent pattern:
```python
state = hass.states.get(entity_id)
value = state.attributes.get("attribute") if state else None
```

The now-unused `from homeassistant.helpers.template import state_attr` import is removed from both files.

## Motivation and Context

In Home Assistant 2026.5.0, `state_attr` was extracted out of `homeassistant.helpers.template` into a dedicated Jinja2 state extension ([home-assistant/core@71fc725](https://github.com/home-assistant/core/commit/71fc725d75c6fbe026cbab86aac8efc32c1ce8e3)). This broke the import and prevented the integration from loading entirely.

- fixes: #449

## How has this been tested?

Manually verified that the integration loads without errors on Home Assistant 2026.5.0. The replaced API calls are functionally equivalent — `state_attr(hass, entity_id, attr)` was itself a thin wrapper around `hass.states.get(entity_id).attributes.get(attr)`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)