### PR TITLE
Add guard for None type

### DIFF
--- a/custom_components/adaptive_cover/calculation.py
+++ b/custom_components/adaptive_cover/calculation.py
@@ -369,6 +369,8 @@ class ClimateCoverData:
             return False
         if self.lux_entity is not None and self.lux_threshold is not None:
             value = get_safe_state(self.hass, self.lux_entity)
+            if value is None:
+                return False
             return float(value) <= self.lux_threshold
         return False
 
@@ -379,6 +381,8 @@ class ClimateCoverData:
             return False
         if self.irradiance_entity is not None and self.irradiance_threshold is not None:
             value = get_safe_state(self.hass, self.irradiance_entity)
+            if value is None:
+                return False
             return float(value) <= self.irradiance_threshold
         return False
 


### PR DESCRIPTION
## Description

When the lux or irradiance sensor returns `None,` the extension crashes and stops working until it is manually restarted.

This PR fixes the issue by properly handling `None` values returned by lux and irradiance sensors.

## Motivation and Context

- fixes:
-fixes type errors in lux and irradiance checks
-prevents extension crashes caused by None sensor values

## How has this been tested?

This fix has been running on my setup for the past 3 weeks without any observed issues or extension crashes.

## Screenshots (if appropriate):

Issue 
<img width="858" height="387" alt="image" src="https://github.com/user-attachments/assets/934952fd-9842-4e4e-8e8c-c38fe3b9b8dc" />


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking which updates existing code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
