### PR TITLE
fix: remove 90° FOV cap for horizontal (awning) covers

### DIFF
--- a/custom_components/adaptive_cover/calculation.py
+++ b/custom_components/adaptive_cover/calculation.py
@@ -534,6 +534,22 @@ class AdaptiveHorizontalCover(AdaptiveVerticalCover):
     awn_length: float
     awn_angle: float
 
+    @property
+    def valid(self) -> bool:
+        """Determine if sun is in front of awning.
+
+        Horizontal awnings shade outdoor areas where the sun can be effective
+        at angles beyond 90° from the window normal. The 90° cap from the base
+        class is intentionally removed here.
+        """
+        valid = (
+            (self.gamma < self.fov_left)
+            & (self.gamma > -self.fov_right)
+            & (self.valid_elevation)
+        )
+        self.logger.debug("Sun in front of awning (ignoring blindspot)? %s", valid)
+        return valid
+
     def calculate_position(self) -> float:
         """Calculate awn length from blind height."""
         awn_angle = 90 - self.awn_angle

--- a/custom_components/adaptive_cover/config_flow.py
+++ b/custom_components/adaptive_cover/config_flow.py
@@ -177,20 +177,37 @@ VERTICAL_OPTIONS = vol.Schema(
 ).extend(OPTIONS.schema)
 
 
-HORIZONTAL_OPTIONS = vol.Schema(
-    {
-        vol.Required(CONF_LENGTH_AWNING, default=2.1): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=0.3, max=6, step=0.01, mode="slider", unit_of_measurement="m"
-            )
-        ),
-        vol.Required(CONF_AWNING_ANGLE, default=0): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=0, max=45, mode="slider", unit_of_measurement="°"
-            )
-        ),
-    }
-).extend(VERTICAL_OPTIONS.schema)
+HORIZONTAL_OPTIONS = (
+    vol.Schema(
+        {
+            vol.Required(CONF_LENGTH_AWNING, default=2.1): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0.3, max=6, step=0.01, mode="slider", unit_of_measurement="m"
+                )
+            ),
+            vol.Required(CONF_AWNING_ANGLE, default=0): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0, max=45, mode="slider", unit_of_measurement="°"
+                )
+            ),
+        }
+    )
+    .extend(VERTICAL_OPTIONS.schema)
+    .extend(
+        {
+            vol.Required(CONF_FOV_LEFT, default=90): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=1, max=180, step=1, mode="slider", unit_of_measurement="°"
+                )
+            ),
+            vol.Required(CONF_FOV_RIGHT, default=90): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=1, max=180, step=1, mode="slider", unit_of_measurement="°"
+                )
+            ),
+        }
+    )
+)
 
 TILT_OPTIONS = vol.Schema(
     {


### PR DESCRIPTION
## Problem

For vertical and tilt blinds, capping FOV at 90° in `AdaptiveGeneralCover.valid` is physically correct — the sun cannot enter a window at more than 90° from the window normal. For **horizontal awnings**, this cap is wrong: an awning shades an outdoor area (terrace, patio) where the sun continues to be effective well past 90° of surface solar azimuth (gamma), particularly in the late afternoon when the sun is low and oblique.

Currently, `solar_times()` already uses the raw FOV values (no cap) to compute `start_sun`/`end_sun` sensor times, but the actual cover position reverts to default as soon as gamma hits ±90° — an inconsistency between the sensor and the cover behaviour.

## Changes

**`calculation.py`** — `AdaptiveHorizontalCover` overrides `valid` without the 90° cap:

```python
@property
def valid(self) -> bool:
    """Determine if sun is in front of awning.

    Horizontal awnings shade outdoor areas where the sun can be effective
    at angles beyond 90° from the window normal. The 90° cap from the base
    class is intentionally removed here.
    """
    valid = (
        (self.gamma < self.fov_left)
        & (self.gamma > -self.fov_right)
        & (self.valid_elevation)
    )
    ...
```

**`config_flow.py`** — `HORIZONTAL_OPTIONS` overrides the FOV selectors with `max=180°`. Vertical and tilt cover configs are unchanged at `max=90°`.

## Behaviour at gamma > 90°

When gamma exceeds 90°, the base `calculate_position` returns 0 (clipped from a negative cosine result), causing the awning to extend to maximum — the correct response for low-angle oblique afternoon sun where maximum shade is appropriate.

## Testing

Verified on a terrace awning (window azimuth 167°, FOV right 105°) where the sun exits the 90° boundary at 16:26 but continues to illuminate the terrace until ~20:44 sunset. With this fix and FOV right set to 105°, the awning correctly stays deployed until ~17:30 without affecting morning behaviour.