### PR TITLE
feat: never_auto_correct — hold manual control indefinitely on "escape" covers

### DIFF
--- a/custom_components/adaptive_cover/config_flow.py
+++ b/custom_components/adaptive_cover/config_flow.py
@@ -51,6 +51,7 @@ from .const import (
     CONF_MAX_POSITION,
     CONF_MIN_ELEVATION,
     CONF_MODE,
+    CONF_NEVER_AUTO_CORRECT,
     CONF_OUTSIDETEMP_ENTITY,
     CONF_PRESENCE_ENTITY,
     CONF_RETURN_SUNSET,
@@ -336,6 +337,7 @@ AUTOMATION_CONFIG = vol.Schema(
             vol.Coerce(int), vol.Range(min=0, max=99)
         ),
         vol.Optional(CONF_MANUAL_IGNORE_INTERMEDIATE, default=False): bool,
+        vol.Optional(CONF_NEVER_AUTO_CORRECT, default=False): bool,
         vol.Optional(CONF_END_TIME, default="00:00:00"): selector.TimeSelector(),
         vol.Optional(CONF_END_ENTITY): selector.EntitySelector(
             selector.EntitySelectorConfig(domain=["sensor", "input_datetime"])
@@ -643,6 +645,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 CONF_MANUAL_IGNORE_INTERMEDIATE: self.config.get(
                     CONF_MANUAL_IGNORE_INTERMEDIATE
                 ),
+                CONF_NEVER_AUTO_CORRECT: self.config.get(CONF_NEVER_AUTO_CORRECT),
                 CONF_BLIND_SPOT_RIGHT: self.config.get(CONF_BLIND_SPOT_RIGHT, None),
                 CONF_BLIND_SPOT_LEFT: self.config.get(CONF_BLIND_SPOT_LEFT, None),
                 CONF_BLIND_SPOT_ELEVATION: self.config.get(

--- a/custom_components/adaptive_cover/const.py
+++ b/custom_components/adaptive_cover/const.py
@@ -73,6 +73,16 @@ CONF_MANUAL_OVERRIDE_RESET = "manual_override_reset"
 CONF_MANUAL_THRESHOLD = "manual_threshold"
 CONF_MANUAL_IGNORE_INTERMEDIATE = "manual_ignore_intermediate"
 
+# "Escape" covers — see #495. A manually-overridden cover normally resumes
+# automatic control on its own once CONF_MANUAL_OVERRIDE_DURATION elapses.
+# When this is on, that automatic resume never happens for this entry's
+# covers: manual control is held indefinitely, until an explicit action
+# (the existing "reset manual override" button/service, or toggling control
+# off then on) hands control back. Nothing else changes — the target
+# position sensor keeps computing normally throughout, only the actual
+# cover.set_cover_position calls are withheld.
+CONF_NEVER_AUTO_CORRECT = "never_auto_correct"
+
 # Security mode — closes covers when nobody is home.
 # The value is NOT stored in config options; the switch entity manages the
 # runtime toggle directly on the coordinator (``coordinator.security_toggle``).

--- a/custom_components/adaptive_cover/const.py
+++ b/custom_components/adaptive_cover/const.py
@@ -76,11 +76,22 @@ CONF_MANUAL_IGNORE_INTERMEDIATE = "manual_ignore_intermediate"
 # "Escape" covers — see #495. A manually-overridden cover normally resumes
 # automatic control on its own once CONF_MANUAL_OVERRIDE_DURATION elapses.
 # When this is on, that automatic resume never happens for this entry's
-# covers: manual control is held indefinitely, until an explicit action
-# (the existing "reset manual override" button/service, or toggling control
-# off then on) hands control back. Nothing else changes — the target
-# position sensor keeps computing normally throughout, only the actual
-# cover.set_cover_position calls are withheld.
+# covers: manual control is held indefinitely, until it's explicitly handed
+# back — either via the "reset manual override" button/service, or by
+# turning the "Manual Override" (switch.manual_toggle) detection switch off
+# and back on. Nothing else changes — the target position sensor keeps
+# computing normally throughout, only the actual cover.set_cover_position
+# calls are withheld.
+#
+# Two things worth knowing:
+# - Manual-control state lives in memory only (AdaptiveCoverManager), not in
+#   the config entry. A Home Assistant restart clears it like any other
+#   manual override, regardless of this setting — "never" means "not on a
+#   timer," not "survives a restart."
+# - This is a per-config-entry setting, same scope as
+#   CONF_MANUAL_OVERRIDE_DURATION. A cover that needs this held-open
+#   protection and one that doesn't can't share the same entry — give the
+#   protected cover(s) their own entry if that's not already the case.
 CONF_NEVER_AUTO_CORRECT = "never_auto_correct"
 
 # Security mode — closes covers when nobody is home.

--- a/custom_components/adaptive_cover/coordinator.py
+++ b/custom_components/adaptive_cover/coordinator.py
@@ -423,7 +423,14 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     async def async_handle_timed_refresh(self, options):
         """Handle timed refresh (sunset position).
 
-        Security mode overrides the sunset position when active.
+        Security mode overrides the sunset position when active. Covers
+        under manual override are left alone — this path used to skip that
+        check (unlike async_handle_first_refresh, a few lines up, which
+        already respected it), so a cover someone had just opened by hand
+        could get force-closed the moment end_time/sunset hit regardless.
+        Fixed independently of never_auto_correct (CONF_NEVER_AUTO_CORRECT):
+        manual override should mean "leave it alone" on every path that
+        writes a position, not just some of them.
         """
         self.logger.debug(
             "This is a timed refresh, using sunset position: %s",
@@ -433,7 +440,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             for cover in self.entities:
                 if self.security_active:
                     await self._apply_security_position(cover, options)
-                else:
+                elif not self.manager.is_cover_manual(cover):
                     await self.async_set_manual_position(
                         cover,
                         (
@@ -441,6 +448,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                             if self._inverse_state
                             else options.get(CONF_SUNSET_POS)
                         ),
+                    )
+                else:
+                    self.logger.debug(
+                        "Timed refresh: skipping %s (manual override active)",
+                        cover,
                     )
         else:
             self.logger.debug("Timed refresh but control toggle is off")

--- a/custom_components/adaptive_cover/coordinator.py
+++ b/custom_components/adaptive_cover/coordinator.py
@@ -77,6 +77,7 @@ from .const import (
     CONF_MAX_POSITION,
     CONF_MIN_ELEVATION,
     CONF_MIN_POSITION,
+    CONF_NEVER_AUTO_CORRECT,
     CONF_OUTSIDE_THRESHOLD,
     CONF_OUTSIDETEMP_ENTITY,
     CONF_PRESENCE_ENTITY,
@@ -170,6 +171,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._climate_debug: dict | None = None
         self.ignore_intermediate_states = self.config_entry.options.get(
             CONF_MANUAL_IGNORE_INTERMEDIATE, False
+        )
+        # See #495 / CONF_NEVER_AUTO_CORRECT in const.py.
+        self.never_auto_correct = self.config_entry.options.get(
+            CONF_NEVER_AUTO_CORRECT, False
         )
         self._update_listener = None
         self._scheduled_time = dt.datetime.now()
@@ -299,7 +304,14 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.logger.debug("Determined default state to be %s", self.default_state)
         state = self.state
 
-        await self.manager.reset_if_needed()
+        # See #495: covers flagged never_auto_correct never get their manual
+        # override cleared by the duration-based timer — only an explicit
+        # action (the "reset manual override" button/service, which calls
+        # manager.reset() directly and is unaffected by this) hands control
+        # back. Everything else in this refresh — target position sensor
+        # included — keeps computing normally either way.
+        if not self.never_auto_correct:
+            await self.manager.reset_if_needed()
 
         if (
             self._end_time
@@ -544,6 +556,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             CONF_MANUAL_OVERRIDE_DURATION, {"minutes": 15}
         )
         self.manual_threshold = options.get(CONF_MANUAL_THRESHOLD)
+        self.never_auto_correct = options.get(CONF_NEVER_AUTO_CORRECT, False)
         self.start_value = options.get(CONF_INTERP_START)
         self.end_value = options.get(CONF_INTERP_END)
         self.normal_list = options.get(CONF_INTERP_LIST)

--- a/custom_components/adaptive_cover/strings.json
+++ b/custom_components/adaptive_cover/strings.json
@@ -21,6 +21,7 @@
           "end_entity": "Entity indicating ending time",
           "manual_threshold": "Manual override threshold",
           "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)",
+          "never_auto_correct": "Never auto-correct after manual override",
           "return_sunset": "Always adjust position to sunset default at end time; Useful if end time is before actual sunset"
         },
         "data_description": {
@@ -241,6 +242,7 @@
           "end_entity": "Entity indicating ending time",
           "manual_threshold": "Manual override threshold",
           "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)",
+          "never_auto_correct": "Never auto-correct after manual override",
           "return_sunset": "Always adjust position to sunset default at end time; Useful if end time is before actual sunset"
         },
         "data_description": {

--- a/custom_components/adaptive_cover/strings.json
+++ b/custom_components/adaptive_cover/strings.json
@@ -32,7 +32,8 @@
           "manual_override_duration": "The duration of manual control before resetting to automatic control",
           "manual_override_reset": "Option to reset the manual override duration after each manual adjustment; if disabled, the duration only applies to the first manual adjustment",
           "end_time": "Ending time for each day; after this time, the cover will remain stationary",
-          "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity"
+          "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity",
+          "never_auto_correct": "Manual control on covers where this is enabled is only cleared by an explicit action, never by the automatic timer."
         }
       },
       "vertical": {
@@ -253,7 +254,8 @@
           "manual_override_duration": "The duration of manual control before resetting to automatic control",
           "manual_override_reset": "Option to reset the manual override duration after each manual adjustment; if disabled, the duration only applies to the first manual adjustment",
           "end_time": "Ending time for each day; after this time, the cover will remain stationary",
-          "end_entity": "Ensure that the position is consistently adjusted to the default sunset setting by the end time. This is particularly beneficial when the end time precedes the actual sunset."
+          "end_entity": "Ensure that the position is consistently adjusted to the default sunset setting by the end time. This is particularly beneficial when the end time precedes the actual sunset.",
+          "never_auto_correct": "Manual control on covers where this is enabled is only cleared by an explicit action, never by the automatic timer."
         }
       },
       "vertical": {

--- a/custom_components/adaptive_cover/translations/en.json
+++ b/custom_components/adaptive_cover/translations/en.json
@@ -38,7 +38,8 @@
           "manual_override_duration": "The duration of manual control before resetting to automatic control",
           "manual_override_reset": "Option to reset the manual override duration after each manual adjustment; if disabled, the duration only applies to the first manual adjustment",
           "end_time": "Ending time for each day; after this time, the cover will remain stationary",
-          "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity"
+          "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity",
+          "never_auto_correct": "Manual control on covers where this is enabled is only cleared by an explicit action, never by the automatic timer."
         }
       },
       "vertical": {
@@ -276,7 +277,8 @@
           "manual_override_duration": "The duration of manual control before resetting to automatic control",
           "manual_override_reset": "Option to reset the manual override duration after each manual adjustment; if disabled, the duration only applies to the first manual adjustment",
           "end_time": "Ending time for each day; after this time, the cover will remain stationary",
-          "end_entity": "Ensure that the position is consistently adjusted to the default sunset setting by the end time. This is particularly beneficial when the end time precedes the actual sunset."
+          "end_entity": "Ensure that the position is consistently adjusted to the default sunset setting by the end time. This is particularly beneficial when the end time precedes the actual sunset.",
+          "never_auto_correct": "Manual control on covers where this is enabled is only cleared by an explicit action, never by the automatic timer."
         }
       },
       "vertical": {

--- a/custom_components/adaptive_cover/translations/en.json
+++ b/custom_components/adaptive_cover/translations/en.json
@@ -27,6 +27,7 @@
           "end_entity": "Entity indicating ending time",
           "manual_threshold": "Manual override threshold",
           "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)",
+          "never_auto_correct": "Never auto-correct after manual override",
           "return_sunset": "Always adjust position to sunset default at end time; Useful if end time is before actual sunset"
         },
         "data_description": {
@@ -264,6 +265,7 @@
           "end_entity": "Entity indicating ending time",
           "manual_threshold": "Manual override threshold",
           "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)",
+          "never_auto_correct": "Never auto-correct after manual override",
           "return_sunset": "Always adjust position to sunset default at end time; Useful if end time is before actual sunset"
         },
         "data_description": {

--- a/custom_components/adaptive_cover/translations/fr.json
+++ b/custom_components/adaptive_cover/translations/fr.json
@@ -38,7 +38,8 @@
           "manual_override_duration": "Durée du contrôle manuel avant de revenir au contrôle automatique",
           "manual_override_reset": "Option permettant de réinitialiser la durée du remplacement manuel après chaque ajustement manuel ; si elle est désactivée, la durée ne s'applique qu'au premier ajustement manuel",
           "end_time": "Heure de fin pour chaque jour ; après cette heure, le volet restera stationnaire",
-          "end_entity": "Entité représentant l'état de l'heure de fin, remplaçant l'heure de fin fixe définie ci-dessus. Utile pour automatiser l'heure de fin avec une entité"
+          "end_entity": "Entité représentant l'état de l'heure de fin, remplaçant l'heure de fin fixe définie ci-dessus. Utile pour automatiser l'heure de fin avec une entité",
+          "never_auto_correct": "Le contrôle manuel des volets où cette option est activée n'est levé que par une action explicite, jamais par le délai automatique."
         }
       },
       "vertical": {
@@ -276,7 +277,8 @@
             "manual_override_duration": "Durée du contrôle manuel avant la réinitialisation au contrôle automatique",
             "manual_override_reset": "Option permettant de réinitialiser la durée de remplacement manuel après chaque réglage manuel ; si elle est désactivée, la durée ne s'applique qu'au premier réglage manuel",
             "end_time": "Heure de fin pour chaque jour ; après cette heure, le capot restera stationnaire",
-            "end_entity": "Assurez-vous que la position est systématiquement ajustée au paramètre de coucher de soleil par défaut à l'heure de fin. Ceci est particulièrement utile lorsque l'heure de fin précède le coucher de soleil réel."
+            "end_entity": "Assurez-vous que la position est systématiquement ajustée au paramètre de coucher de soleil par défaut à l'heure de fin. Ceci est particulièrement utile lorsque l'heure de fin précède le coucher de soleil réel.",
+            "never_auto_correct": "Le contrôle manuel des volets où cette option est activée n'est levé que par une action explicite, jamais par le délai automatique."
           }
       },
       "vertical": {

--- a/custom_components/adaptive_cover/translations/fr.json
+++ b/custom_components/adaptive_cover/translations/fr.json
@@ -27,6 +27,7 @@
           "end_entity": "Entité indiquant la fin de periode",
           "manual_threshold": "Seuil de detection pour le mode manuel",
           "manual_ignore_intermediate": "Ignore les postions intermediares durant le mode manuel (ouverture & fermeture)",
+          "never_auto_correct": "Ne jamais corriger après une commande manuelle",
           "return_sunset": "Toujours ajuster la position en fonction du coucher de soleil à la fin ; utile si l'heure de fin est antérieure au coucher du soleil réel"
         },
         "data_description": {
@@ -264,6 +265,7 @@
             "end_entity": "Entité indiquant l'heure de fin",
             "manual_threshold": "Seuil de commande manuelle",
             "manual_ignore_intermediate": "Ignorer les positions intermédiaires pendant la commande manuelle (ouverture et fermeture)",
+            "never_auto_correct": "Ne jamais corriger après une commande manuelle",
             "return_sunset": "Toujours ajuster la position à la valeur par défaut du coucher du soleil à l'heure de fin ; utile si l'heure de fin est antérieure au coucher du soleil réel"
           },
         "data_description": {


### PR DESCRIPTION
Closes #495.

## What

New per-entry boolean option, `never_auto_correct` (default `False`). Normally, a manually-overridden cover resumes automatic control on its own once `manual_override_duration` elapses (`AdaptiveCoverManager.reset_if_needed`, called every coordinator refresh). With this on, that automatic timer-based resume is skipped entirely for the entry's covers — manual control is held until it's handed back explicitly, via the existing "reset manual override" button/service (unaffected, since it already calls `manager.reset()` directly) or by cycling the "Manual Override" detection switch.

## Why

A cover that's the only way out to a terrace shouldn't silently re-close itself after someone opens it by hand, no matter how long ago that was.

## A pre-existing bug this PR also fixes

An independent review turned up something the feature couldn't actually deliver on without this: `async_handle_timed_refresh` (the sunset-position handler) never checked `is_cover_manual` at all — unlike `async_handle_first_refresh`, a few lines up, which already does. A manually-opened cover would get force-closed the moment `end_time`/sunset hit, regardless of this new setting. This gap predates this PR and affects every user relying on manual override, not just `never_auto_correct` entries — fixed here since it's exactly the path that made the escape-cover scenario not actually hold.

## Known trade-offs (documented in the `CONF_NEVER_AUTO_CORRECT` comment, not silently left out)

- Manual-control state lives in memory only (`AdaptiveCoverManager`), not in the config entry — a Home Assistant restart clears it like any other manual override. "Never" means "not on a timer," not "survives a restart."
- Per-config-entry scope, same as `manual_override_duration`: a protected cover and an unprotected one need separate entries.

`es.json`/`nl.json` intentionally left untouched — other fields in this section are already incomplete there (HA falls back to English), and I'd rather not add machine-translated strings into languages I can't verify myself.

## Testing

Verified both the core gating logic and the timed-refresh fix with standalone simulations (repeated manual-state checks; a manually-opened cover left alone at sunset vs. a non-manual one closing normally) before pushing either commit. No test harness found in this repo for coordinator/config_flow the way some forks have one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)