### PR TITLE
feat: optional window/door sensor blocks algorithmic closing moves

### DIFF
--- a/custom_components/adaptive_cover/__init__.py
+++ b/custom_components/adaptive_cover/__init__.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_IRRADIANCE_ENTITY,
     CONF_IS_HUB,
     CONF_LUX_ENTITY,
+    CONF_OPENING_ENTITY,
     CONF_OUTSIDETEMP_ENTITY,
     CONF_PRESENCE_ENTITY,
     CONF_START_ENTITY,
@@ -148,6 +149,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _irradiance_entity = entry.options.get(CONF_IRRADIANCE_ENTITY)
     _outside_temp_entity = entry.options.get(CONF_OUTSIDETEMP_ENTITY)
     _start_time_entity = entry.options.get(CONF_START_ENTITY)
+    _opening_entity = entry.options.get(CONF_OPENING_ENTITY)
     _entities = ["sun.sun"]
     for entity in [
         _temp_entity,
@@ -158,6 +160,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _irradiance_entity,
         _outside_temp_entity,
         _start_time_entity,
+        _opening_entity,
     ]:
         if entity is not None:
             _entities.append(entity)

--- a/custom_components/adaptive_cover/button.py
+++ b/custom_components/adaptive_cover/button.py
@@ -82,7 +82,12 @@ class AdaptiveCoverButton(
         for entity in self._entities:
             if self.coordinator.manager.is_cover_manual(entity):
                 _LOGGER.debug("Resetting manual override for: %s", entity)
-                await self.coordinator.async_set_position(
+                # The position applied here is the algorithm's own
+                # (coordinator.state), not a fresh user choice — this
+                # button means "resume automatic control", so it's guarded
+                # by the opening sensor like any other algorithmic move
+                # (#498). See async_set_adaptive_position.
+                await self.coordinator.async_set_adaptive_position(
                     entity, self.coordinator.state
                 )
                 while self.coordinator.wait_for_target.get(entity):

--- a/custom_components/adaptive_cover/button.py
+++ b/custom_components/adaptive_cover/button.py
@@ -87,11 +87,21 @@ class AdaptiveCoverButton(
                 # button means "resume automatic control", so it's guarded
                 # by the opening sensor like any other algorithmic move
                 # (#498). See async_set_adaptive_position.
-                await self.coordinator.async_set_adaptive_position(
+                #
+                # A withheld move (door open) never sets wait_for_target —
+                # that only happens inside async_set_manual_position, right
+                # before the actual service call — so waiting on it here
+                # unconditionally would hang forever. Only wait when the
+                # move was actually sent. Automatic control is resumed
+                # (manager.reset) either way: that's the button's actual
+                # purpose, and once the door closes, the next refresh will
+                # apply the pending position on its own.
+                applied = await self.coordinator.async_set_adaptive_position(
                     entity, self.coordinator.state
                 )
-                while self.coordinator.wait_for_target.get(entity):
-                    await asyncio.sleep(1)
+                if applied:
+                    while self.coordinator.wait_for_target.get(entity):
+                        await asyncio.sleep(1)
                 self.coordinator.manager.reset(entity)
             else:
                 _LOGGER.debug(

--- a/custom_components/adaptive_cover/config_flow.py
+++ b/custom_components/adaptive_cover/config_flow.py
@@ -77,6 +77,7 @@ from .const import (
     CONF_ENABLE_MIN_POSITION,
     CONF_IS_HUB,
     ALL_BLINDS_TITLE,
+    CONF_OPENING_ENTITY,
 )
 
 # DEFAULT_NAME = "Adaptive Cover"
@@ -336,6 +337,9 @@ AUTOMATION_CONFIG = vol.Schema(
             vol.Coerce(int), vol.Range(min=0, max=99)
         ),
         vol.Optional(CONF_MANUAL_IGNORE_INTERMEDIATE, default=False): bool,
+        vol.Optional(CONF_OPENING_ENTITY): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain=["binary_sensor", "input_boolean"])
+        ),
         vol.Optional(CONF_END_TIME, default="00:00:00"): selector.TimeSelector(),
         vol.Optional(CONF_END_ENTITY): selector.EntitySelector(
             selector.EntitySelectorConfig(domain=["sensor", "input_datetime"])
@@ -643,6 +647,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 CONF_MANUAL_IGNORE_INTERMEDIATE: self.config.get(
                     CONF_MANUAL_IGNORE_INTERMEDIATE
                 ),
+                CONF_OPENING_ENTITY: self.config.get(CONF_OPENING_ENTITY),
                 CONF_BLIND_SPOT_RIGHT: self.config.get(CONF_BLIND_SPOT_RIGHT, None),
                 CONF_BLIND_SPOT_LEFT: self.config.get(CONF_BLIND_SPOT_LEFT, None),
                 CONF_BLIND_SPOT_ELEVATION: self.config.get(
@@ -711,7 +716,12 @@ class OptionsFlowHandler(OptionsFlow):
     async def async_step_automation(self, user_input: dict[str, Any] | None = None):
         """Manage automation options."""
         if user_input is not None:
-            entities = [CONF_START_ENTITY, CONF_END_ENTITY, CONF_MANUAL_THRESHOLD]
+            entities = [
+                CONF_START_ENTITY,
+                CONF_END_ENTITY,
+                CONF_MANUAL_THRESHOLD,
+                CONF_OPENING_ENTITY,
+            ]
             self.optional_entities(entities, user_input)
             self.options.update(user_input)
             return await self._update_options()

--- a/custom_components/adaptive_cover/const.py
+++ b/custom_components/adaptive_cover/const.py
@@ -73,6 +73,13 @@ CONF_MANUAL_OVERRIDE_RESET = "manual_override_reset"
 CONF_MANUAL_THRESHOLD = "manual_threshold"
 CONF_MANUAL_IGNORE_INTERMEDIATE = "manual_ignore_intermediate"
 
+# Optional window/door contact sensor — see #498. While it reports open,
+# algorithmic (not user-explicit) closing moves are withheld for this
+# entry's covers. An unknown/unavailable state counts as OPEN, never
+# closed — a dead battery must degrade to "no protection", not "lie
+# closed" (see helpers.is_opening_open for the full fail-safe contract).
+CONF_OPENING_ENTITY = "opening_entity"
+
 # Security mode — closes covers when nobody is home.
 # The value is NOT stored in config options; the switch entity manages the
 # runtime toggle directly on the coordinator (``coordinator.security_toggle``).

--- a/custom_components/adaptive_cover/coordinator.py
+++ b/custom_components/adaptive_cover/coordinator.py
@@ -77,6 +77,7 @@ from .const import (
     CONF_MAX_POSITION,
     CONF_MIN_ELEVATION,
     CONF_MIN_POSITION,
+    CONF_OPENING_ENTITY,
     CONF_OUTSIDE_THRESHOLD,
     CONF_OUTSIDETEMP_ENTITY,
     CONF_PRESENCE_ENTITY,
@@ -98,7 +99,13 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
-from .helpers import get_datetime_from_str, get_last_updated, get_safe_state, is_presence_detected
+from .helpers import (
+    get_datetime_from_str,
+    get_last_updated,
+    get_safe_state,
+    is_opening_open,
+    is_presence_detected,
+)
 
 
 @dataclass
@@ -352,6 +359,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     options.get(CONF_FOV_RIGHT),
                 ],
                 "blind_spot": options.get(CONF_BLIND_SPOT_ELEVATION),
+                "opening_open": (
+                    is_opening_open(self.hass, options.get(CONF_OPENING_ENTITY))
+                    if options.get(CONF_OPENING_ENTITY)
+                    else None
+                ),
             },
             climate_debug=self._climate_debug,
         )
@@ -402,7 +414,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     and not self.manager.is_cover_manual(cover)
                     and self.check_position_delta(cover, state, options)
                 ):
-                    await self.async_set_position(cover, state)
+                    await self.async_set_adaptive_position(cover, state, options)
         else:
             self.logger.debug("First refresh but control toggle is off")
         self.first_refresh = False
@@ -422,13 +434,14 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 if self.security_active:
                     await self._apply_security_position(cover, options)
                 else:
-                    await self.async_set_manual_position(
+                    await self.async_set_adaptive_position(
                         cover,
                         (
                             inverse_state(options.get(CONF_SUNSET_POS))
                             if self._inverse_state
                             else options.get(CONF_SUNSET_POS)
                         ),
+                        options,
                     )
         else:
             self.logger.debug("Timed refresh but control toggle is off")
@@ -443,10 +456,60 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             and self.check_time_delta(entity)
             and not self.manager.is_cover_manual(entity)
         ):
-            await self.async_set_position(entity, state)
+            await self.async_set_adaptive_position(entity, state, options)
 
     async def async_set_position(self, entity, state: int):
-        """Call service to set cover position."""
+        """Call service to set cover position.
+
+        Explicit, user-requested position — the cover entity, the
+        All-Blinds hub scenes/select, and the like all call this directly.
+        NOT guarded by the opening sensor (#498): a user asking a cover to
+        close is a deliberate act, not an algorithmic decision the sensor
+        is meant to intercept. See async_set_adaptive_position for the
+        algorithm-chosen counterpart, which is guarded.
+        """
+        await self.async_set_manual_position(entity, state)
+
+    def _closing_blocked_by_opening(self, options, entity: str, target: int) -> bool:
+        """Return True when *target* would close *entity* while its opening sensor is open.
+
+        Only downward moves are blocked (target < current position) —
+        opening moves and no-ops always pass, so this can never itself
+        cause a shutter to trap someone, only prevent one from closing on
+        an open door.
+
+        current position unknown (None) -> returns False, i.e. not
+        blocked. That's safe, not lax: check_position() already suppresses
+        the service call entirely when the current position can't be
+        read, so no movement happens in that case regardless.
+        """
+        entity_id = options.get(CONF_OPENING_ENTITY)
+        if not is_opening_open(self.hass, entity_id):
+            return False
+        current = self._get_current_position(entity)
+        if current is None:
+            return False
+        return target < current
+
+    async def async_set_adaptive_position(self, entity, state: int, options=None) -> None:
+        """Apply an ALGORITHM-chosen position, honoring the opening guard.
+
+        Counterpart of async_set_position, reserved for positions the
+        integration itself decided on (state-change recompute, first
+        refresh, sunset position, security mode, the manual-override reset
+        button/switch). See #498: while a configured window/door sensor
+        reports open (or is unavailable/unknown — fail-safe, never
+        silently treated as closed), a move that would close this cover is
+        withheld rather than sent.
+        """
+        options = options if options is not None else self.config_entry.options
+        if self._closing_blocked_by_opening(options, entity, state):
+            self.logger.debug(
+                "Closing move to %s%% withheld for %s: opening sensor reports open",
+                state,
+                entity,
+            )
+            return
         await self.async_set_manual_position(entity, state)
 
     async def async_set_manual_position(self, entity, state):
@@ -488,6 +551,16 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         ``manager.mark_manual_control`` — security is not a user gesture and
         must not block the automatic return to adaptive positioning when
         presence is restored.
+
+        Unlike #501's ``never_auto_correct`` guard, which security mode
+        deliberately overrides, the window/door opening guard (#498) DOES
+        apply here: security mode fires exactly when no presence is
+        detected, which is the canonical false-negative case (someone on
+        the terrace, phone left indoors). Closing a shutter over a
+        physically open door protects nothing — the opening stays
+        crossable regardless — and can trap a person. A security move that
+        *opens* the cover (target above its current position) is never
+        affected; only a close onto an open door is withheld.
         """
         if self.manager.is_cover_manual(entity):
             self.logger.debug(
@@ -510,7 +583,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 entity,
             )
 
-        await self.async_set_manual_position(entity, pos)
+        await self.async_set_adaptive_position(entity, pos, options)
 
     @property
     def security_active(self) -> bool:

--- a/custom_components/adaptive_cover/coordinator.py
+++ b/custom_components/adaptive_cover/coordinator.py
@@ -491,7 +491,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             return False
         return target < current
 
-    async def async_set_adaptive_position(self, entity, state: int, options=None) -> None:
+    async def async_set_adaptive_position(
+        self, entity, state: int, options=None
+    ) -> bool:
         """Apply an ALGORITHM-chosen position, honoring the opening guard.
 
         Counterpart of async_set_position, reserved for positions the
@@ -501,6 +503,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         reports open (or is unavailable/unknown — fail-safe, never
         silently treated as closed), a move that would close this cover is
         withheld rather than sent.
+
+        Returns True if the move was actually sent (or bypassed the guard
+        because it wasn't a closing move), False if withheld. Callers that
+        wait on wait_for_target after this — currently only button.py's
+        manual-override reset — must check this before waiting: a withheld
+        move never sets wait_for_target (that only happens inside
+        async_set_manual_position, right before the service call), so
+        waiting on it unconditionally would hang forever whenever this
+        returns False.
         """
         options = options if options is not None else self.config_entry.options
         if self._closing_blocked_by_opening(options, entity, state):
@@ -509,8 +520,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 state,
                 entity,
             )
-            return
+            return False
         await self.async_set_manual_position(entity, state)
+        return True
 
     async def async_set_manual_position(self, entity, state):
         """Call service to set cover position."""

--- a/custom_components/adaptive_cover/helpers.py
+++ b/custom_components/adaptive_cover/helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime as dt
 
 from dateutil import parser
+from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant, split_entity_id
 
 
@@ -82,6 +83,47 @@ def is_presence_detected(hass: HomeAssistant, entity_id: str | None) -> bool:
     if domain in ("binary_sensor", "input_boolean"):
         return state == "on"
     return True
+
+
+def is_opening_open(hass: HomeAssistant, entity_id: str | None) -> bool:
+    """Return True when the window/door is open — or when we cannot tell.
+
+    Fail-safe contract (issue #498): a dead battery, a dropped Zigbee
+    device, or a deleted entity must degrade to "as if there were no
+    sensor at all", never to "closed". A sensor that lies is worse than no
+    sensor — this mirrors is_presence_detected above, but note the
+    direction is INVERTED: there, the safe default is "present" and the
+    test is `== "on"`; here, the safe default is "open" and the test is
+    `!= "off"`. Only the exact string "off" may conclude "closed" — an
+    unexpected value (a typo, a non-boolean template state, "On" with a
+    stray capital) must fail toward "open", the same way "unknown" does.
+
+    Supported domains (HA convention for binary_sensor device_class door /
+    window / opening / garage_door: "on" means open):
+      - ``binary_sensor`` : "off" → closed, anything else → open
+      - ``input_boolean`` : same
+
+    Open (fail-safe) for:
+      - ``entity_id`` is None            → actually returns False: no
+        sensor configured means nothing to guard against, not "assume the
+        worst". This is the one case that is NOT fail-safe on purpose.
+      - entity missing from ``hass.states``, state "unknown"/"unavailable"
+      - a non-string or empty state
+      - any domain other than the two above
+    """
+    if entity_id is None:
+        return False  # no sensor configured → never blocks
+
+    state = get_safe_state(hass, entity_id)
+    if state is None:
+        return True  # missing/unknown/unavailable → fail-safe
+
+    if not isinstance(state, str) or not state.strip():
+        return True  # fail-safe
+
+    if get_domain(entity_id) in ("binary_sensor", "input_boolean"):
+        return state != STATE_OFF  # NOT "== STATE_ON" — see docstring above
+    return True  # unrecognized domain → fail-safe
 
 
 def iter_regular_coordinators(hass: HomeAssistant):

--- a/custom_components/adaptive_cover/strings.json
+++ b/custom_components/adaptive_cover/strings.json
@@ -21,6 +21,7 @@
           "end_entity": "Entity indicating ending time",
           "manual_threshold": "Manual override threshold",
           "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)",
+          "opening_entity": "Window or door sensor (optional)",
           "return_sunset": "Always adjust position to sunset default at end time; Useful if end time is before actual sunset"
         },
         "data_description": {
@@ -31,6 +32,7 @@
           "manual_override_duration": "The duration of manual control before resetting to automatic control",
           "manual_override_reset": "Option to reset the manual override duration after each manual adjustment; if disabled, the duration only applies to the first manual adjustment",
           "end_time": "Ending time for each day; after this time, the cover will remain stationary",
+          "opening_entity": "Contact sensor for a window or door. While it reports open, the integration will not close this cover automatically. An unknown or unavailable sensor counts as open, so a flat battery degrades the protection instead of closing on an open door.",
           "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity"
         }
       },
@@ -241,6 +243,7 @@
           "end_entity": "Entity indicating ending time",
           "manual_threshold": "Manual override threshold",
           "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)",
+          "opening_entity": "Window or door sensor (optional)",
           "return_sunset": "Always adjust position to sunset default at end time; Useful if end time is before actual sunset"
         },
         "data_description": {
@@ -251,6 +254,7 @@
           "manual_override_duration": "The duration of manual control before resetting to automatic control",
           "manual_override_reset": "Option to reset the manual override duration after each manual adjustment; if disabled, the duration only applies to the first manual adjustment",
           "end_time": "Ending time for each day; after this time, the cover will remain stationary",
+          "opening_entity": "Contact sensor for a window or door. While it reports open, the integration will not close this cover automatically. An unknown or unavailable sensor counts as open, so a flat battery degrades the protection instead of closing on an open door.",
           "end_entity": "Ensure that the position is consistently adjusted to the default sunset setting by the end time. This is particularly beneficial when the end time precedes the actual sunset."
         }
       },

--- a/custom_components/adaptive_cover/switch.py
+++ b/custom_components/adaptive_cover/switch.py
@@ -199,7 +199,11 @@ class AdaptiveCoverSwitch(
                     not self.coordinator.manager.is_cover_manual(entity)
                     and self.coordinator.check_adaptive_time
                 ):
-                    await self.coordinator.async_set_position(
+                    # Position is the algorithm's own (coordinator.state):
+                    # this switch means "resume automatic control", not a
+                    # fresh user-chosen position — guarded like any other
+                    # algorithmic move (#498).
+                    await self.coordinator.async_set_adaptive_position(
                         entity, self.coordinator.state
                     )
         await self.coordinator.async_refresh()

--- a/custom_components/adaptive_cover/translations/en.json
+++ b/custom_components/adaptive_cover/translations/en.json
@@ -27,6 +27,7 @@
           "end_entity": "Entity indicating ending time",
           "manual_threshold": "Manual override threshold",
           "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)",
+          "opening_entity": "Window or door sensor (optional)",
           "return_sunset": "Always adjust position to sunset default at end time; Useful if end time is before actual sunset"
         },
         "data_description": {
@@ -37,6 +38,7 @@
           "manual_override_duration": "The duration of manual control before resetting to automatic control",
           "manual_override_reset": "Option to reset the manual override duration after each manual adjustment; if disabled, the duration only applies to the first manual adjustment",
           "end_time": "Ending time for each day; after this time, the cover will remain stationary",
+          "opening_entity": "Contact sensor for a window or door. While it reports open, the integration will not close this cover automatically. An unknown or unavailable sensor counts as open, so a flat battery degrades the protection instead of closing on an open door.",
           "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity"
         }
       },
@@ -264,6 +266,7 @@
           "end_entity": "Entity indicating ending time",
           "manual_threshold": "Manual override threshold",
           "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)",
+          "opening_entity": "Window or door sensor (optional)",
           "return_sunset": "Always adjust position to sunset default at end time; Useful if end time is before actual sunset"
         },
         "data_description": {
@@ -274,6 +277,7 @@
           "manual_override_duration": "The duration of manual control before resetting to automatic control",
           "manual_override_reset": "Option to reset the manual override duration after each manual adjustment; if disabled, the duration only applies to the first manual adjustment",
           "end_time": "Ending time for each day; after this time, the cover will remain stationary",
+          "opening_entity": "Contact sensor for a window or door. While it reports open, the integration will not close this cover automatically. An unknown or unavailable sensor counts as open, so a flat battery degrades the protection instead of closing on an open door.",
           "end_entity": "Ensure that the position is consistently adjusted to the default sunset setting by the end time. This is particularly beneficial when the end time precedes the actual sunset."
         }
       },

--- a/custom_components/adaptive_cover/translations/fr.json
+++ b/custom_components/adaptive_cover/translations/fr.json
@@ -27,6 +27,7 @@
           "end_entity": "Entité indiquant la fin de periode",
           "manual_threshold": "Seuil de detection pour le mode manuel",
           "manual_ignore_intermediate": "Ignore les postions intermediares durant le mode manuel (ouverture & fermeture)",
+          "opening_entity": "Capteur de fenêtre ou de porte (optionnel)",
           "return_sunset": "Toujours ajuster la position en fonction du coucher de soleil à la fin ; utile si l'heure de fin est antérieure au coucher du soleil réel"
         },
         "data_description": {
@@ -37,6 +38,7 @@
           "manual_override_duration": "Durée du contrôle manuel avant de revenir au contrôle automatique",
           "manual_override_reset": "Option permettant de réinitialiser la durée du remplacement manuel après chaque ajustement manuel ; si elle est désactivée, la durée ne s'applique qu'au premier ajustement manuel",
           "end_time": "Heure de fin pour chaque jour ; après cette heure, le volet restera stationnaire",
+          "opening_entity": "Capteur d'ouverture d'une fenêtre ou d'une porte. Tant qu'il indique « ouvert », l'intégration ne ferme plus ce volet automatiquement. Un capteur inconnu ou indisponible est compté comme ouvert : une pile vide dégrade la protection au lieu de fermer sur une porte ouverte.",
           "end_entity": "Entité représentant l'état de l'heure de fin, remplaçant l'heure de fin fixe définie ci-dessus. Utile pour automatiser l'heure de fin avec une entité"
         }
       },
@@ -264,6 +266,7 @@
             "end_entity": "Entité indiquant l'heure de fin",
             "manual_threshold": "Seuil de commande manuelle",
             "manual_ignore_intermediate": "Ignorer les positions intermédiaires pendant la commande manuelle (ouverture et fermeture)",
+            "opening_entity": "Capteur de fenêtre ou de porte (optionnel)",
             "return_sunset": "Toujours ajuster la position à la valeur par défaut du coucher du soleil à l'heure de fin ; utile si l'heure de fin est antérieure au coucher du soleil réel"
           },
         "data_description": {
@@ -274,6 +277,7 @@
             "manual_override_duration": "Durée du contrôle manuel avant la réinitialisation au contrôle automatique",
             "manual_override_reset": "Option permettant de réinitialiser la durée de remplacement manuel après chaque réglage manuel ; si elle est désactivée, la durée ne s'applique qu'au premier réglage manuel",
             "end_time": "Heure de fin pour chaque jour ; après cette heure, le capot restera stationnaire",
+            "opening_entity": "Capteur d'ouverture d'une fenêtre ou d'une porte. Tant qu'il indique « ouvert », l'intégration ne ferme plus ce volet automatiquement. Un capteur inconnu ou indisponible est compté comme ouvert : une pile vide dégrade la protection au lieu de fermer sur une porte ouverte.",
             "end_entity": "Assurez-vous que la position est systématiquement ajustée au paramètre de coucher de soleil par défaut à l'heure de fin. Ceci est particulièrement utile lorsque l'heure de fin précède le coucher de soleil réel."
           }
       },


### PR DESCRIPTION
Closes #498.

## What

New optional per-entry setting, `opening_entity` (`binary_sensor` or `input_boolean`). While it reports open, algorithmic closing moves are withheld for this entry's covers. An unknown/unavailable state counts as OPEN, never closed — a dead battery must degrade to "no protection", not "lie closed". Not configured (every existing config) → unchanged behavior.

## Why

A cover that's the only way out to a terrace shouldn't close on someone who's outside, even when nothing about their presence detection or manual-override state (#501, separate concern) would otherwise stop it.

## The exhaustive-paths problem, and how this PR is built to survive it

There is exactly one `hass.services.async_call(COVER_DOMAIN, ...)` in the whole integration, inside `async_set_manual_position` — every cover move goes through it. That single choke point makes six call sites demonstrably the complete set of places an ALGORITHMIC position gets applied: `async_handle_call_service`, `async_handle_first_refresh`, `async_handle_timed_refresh`, `_apply_security_position` (`coordinator.py`), `button.AdaptiveCoverButton.async_press` (the "reset manual override" button — the position it applies is the algorithm's own, `coordinator.state`, even though the button press itself is a human gesture), and `switch.AdaptiveCoverSwitch.async_turn_on` for `control_toggle` (same reasoning). All six now go through a new `async_set_adaptive_position` instead of `async_set_position` directly.

A second, disjoint set of six sites applies a position a HUMAN explicitly chose: `cover.py`'s three entity actions, the All-Blinds hub's `_move_all`, `select.py`'s hub mode, `scene.py`. These are deliberately NOT guarded — a `cover.close_cover` call, or a "close all" scene, that silently no-ops is a Home Assistant contract violation, not a safety feature, and it would mean a lying sensor could make a cover impossible to close by any means. `async_set_position` (still used by all six) gained a docstring saying so explicitly.

## Mechanism

- `helpers.is_opening_open(hass, entity_id)`: the fail-safe resolver, same shape as the existing `is_presence_detected`, but with the safe direction inverted — there, `"on"`/present is the assumed-safe state; here, only the exact string `"off"` may conclude "closed", so a stray `"On"` typo or an unexpected template value fails toward "open" exactly like `"unknown"` does. `entity_id=None` returns `False` (not fail-safe on purpose: no sensor configured means nothing to guard against).
- `coordinator._closing_blocked_by_opening(options, entity, target)`: relative to the cover's CURRENT position, not absolute — only `target < current_position` blocks. An opening move or a no-op always passes.
- `coordinator.async_set_adaptive_position(entity, state, options=None)`: the new single entry point for algorithmic moves.

## Security mode diverges from #501's precedent, on purpose

`_apply_security_position` ignores #501's `never_auto_correct` guard (security is not a user gesture, it must be free to reclaim a cover), but DOES respect this one. Security fires exactly when no presence is detected — the canonical false-negative case is someone outside without their phone. Closing a shutter over a physically open door protects nothing and can trap a person. An opening move requested by security is never affected.

## Configuration

`CONF_OPENING_ENTITY` lives in `AUTOMATION_CONFIG`, not `CLIMATE_OPTIONS`, despite the issue's "for climate mode" phrasing: climate mode's schema is invisible to any entry running in basic mode, but basic mode closes too. `AUTOMATION_CONFIG` is unconditional for every entry, and already home to the same family of behavior guards (`manual_override_*`, `never_auto_correct` from #501). `EntitySelector` restricted to `binary_sensor` and `input_boolean` — the two domains the resolver understands, no `device_class` filter (many real contact sensors don't declare one).

Added to `__init__.py`'s tracked-entity list so a door closing physically wakes the coordinator, and to the options-flow's `optional_entities` list so clearing the sensor in the UI actually clears it.

## Scope

One policy only: block the closing move. The fork at rako79/adaptive-cover has four (pause / go to a safe position / block-closing-only / pause-and-return); this implements the equivalent of the third, because it's the only one that's strictly safety-monotone — it removes a move rather than triggering one in response to a sensor that might itself be unreliable. A follow-up PR could add a policy selector additively.

## Found by review, fixed before this PR was opened

- `button.py`'s "reset manual override" press could hang forever (and never actually resume automatic control) if `wait_for_target` held a stale `True` from an unrelated prior move, on any press where the move gets withheld. `async_set_adaptive_position` now returns whether the move was sent; the button only waits when it was, and always resumes control (`manager.reset`) regardless — that's the button's actual purpose.
- A second finding — that the closing comparison might need to account for `CONF_INVERSE_STATE` — was traced and not applied: the two pre-existing sibling comparisons on the same values (`check_position`, `check_position_delta`) do the identical raw comparison with no such handling, and `inverse_state()` is applied exactly once (in the `state` property) before any comparison site ever sees the value. Adding a flip here would make this function disagree with its siblings on the same numbers.

## Testing

Verified with standalone simulations before each push: the `is_opening_open` contract against every edge case (no sensor / missing entity / unknown / unavailable / empty / non-string / unrecognized domain / `"off"` / `"on"` / a stray `"On"` typo); the relative-blocking rule (full close blocked, partial close blocked, opening never blocked, no-op never blocked, unknown current position never blocked); the security-mode scenario (an opening move passes even with the sensor reporting open); and the button fix (a stale `wait_for_target` no longer hangs the press, and automatic control resumes either way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)